### PR TITLE
🦆 Fix Pause Bug: Obstacles Spawning During Pause 🛑

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -14,7 +14,7 @@ export class GameScene extends Phaser.Scene {
   private riverManager!: RiverManager;
   private obstacleManager!: ObstacleManager;
   private jamManager!: JamManager;
-  private pauseManager!: PauseManager;
+  public pauseManager!: PauseManager;
   private scoreManager!: ScoreManager;
   private gameOverManager!: GameOverManager;
   private bgMusic!: Phaser.Sound.BaseSound;


### PR DESCRIPTION
🦆 Fix Pause Bug: Obstacles Spawning During Pause 🛑

  Summary

  - Fixed a critical bug where obstacles continued to spawn while the game was paused
  - Changed obstacle spawning system to use proper pausable timers instead of non-pausable delayed calls
  - Made the pause manager accessible to other game systems for better integration

  Technical Details

  - Replaced delayedCall with addEvent to create proper timer objects that can be paused
  - Register additional obstacle spawn timers with the PauseManager
  - Made PauseManager public in GameScene so it can be accessed from other managers
